### PR TITLE
Update for iOS 17, macOS 14 and visionOS

### DIFF
--- a/Sources/FrameUp/SmartScrollView/SmartScrollView.swift
+++ b/Sources/FrameUp/SmartScrollView/SmartScrollView.swift
@@ -183,6 +183,13 @@ public struct SmartScrollView<Content: View>: View {
                     .fixedSize(horizontal: axes.contains(.horizontal), vertical: axes.contains(.vertical))
 //                    .opacity(state == nil ? 0 : 1)
             }
+            .ifAvailable {
+                if #available(iOS 17, *) {
+                    $0.scrollBounceBehavior(optionalScrolling ? .basedOnSize : .always)
+                } else {
+                    $0
+                }
+            }
         }
         /// A frame that's able to shrink the scroll view is applied only when the state is known.
         .frame(maxWidth: state?.scrollView.width, maxHeight: state?.scrollView.height)

--- a/Sources/FrameUp/TwoSidedView/BackfaceCull.swift
+++ b/Sources/FrameUp/TwoSidedView/BackfaceCull.swift
@@ -1,0 +1,28 @@
+//
+//  BackfaceCull.swift
+//  FrameUp
+//
+//  Created by Ryan Lintott on 2023-09-06.
+//
+
+import SwiftUI
+
+/// A shape that draws a rectangle matching the frame when the rotation angle is facing forward (angles between -90 and 90 degrees) and nothing when facing backwards (angles between 90 and 270 degrees).
+struct BackfaceCull: Shape {
+    /// Degrees of rotation. Any additional 360 degree rotaitons will be removed before evaluating.
+    var degrees: CGFloat
+    
+    var animatableData: CGFloat {
+        get { degrees }
+        set { degrees = newValue }
+    }
+    
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        switch abs(degrees).truncatingRemainder(dividingBy: 360) {
+        case 90...270: break
+        default: path.addRect(rect)
+        }
+        return path
+    }
+}

--- a/Sources/FrameUp/TwoSidedView/FlippingView.swift
+++ b/Sources/FrameUp/TwoSidedView/FlippingView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(visionOS, deprecated, message: "No replacement at this time")
 public struct FlippingView<Front: View, Back: View>: View {
     let axis: Axis
     @Binding var flips: Int
@@ -154,6 +155,7 @@ public struct FlippingView<Front: View, Back: View>: View {
     }
 }
 
+@available(visionOS, deprecated, message: "No replacement at this time")
 struct FlippingView_Previews: PreviewProvider {
     struct PreviewData: View {
         @State private var flips: Int = 0

--- a/Sources/FrameUp/TwoSidedView/TwoSidedView.swift
+++ b/Sources/FrameUp/TwoSidedView/TwoSidedView.swift
@@ -1,32 +1,13 @@
 //
 //  TwoSidedView.swift
-//  FrameUpExample
+//  FrameUp
 //
 //  Created by Ryan Lintott on 2022-07-11.
 //
 
 import SwiftUI
 
-/// A shape that draws a rectangle matching the frame when the rotation angle is facing forward (angles between -90 and 90 degrees) and nothing when facing backwards (angles between 90 and 270 degrees).
-fileprivate struct BackfaceCull: Shape {
-    /// Degrees of rotation. Any additional 360 degree rotaitons will be removed before evaluating.
-    var degrees: CGFloat
-    
-    var animatableData: CGFloat {
-        get { degrees }
-        set { degrees = newValue }
-    }
-    
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        switch abs(degrees).truncatingRemainder(dividingBy: 360) {
-        case 90...270: break
-        default: path.addRect(rect)
-        }
-        return path
-    }
-}
-
+@available(visionOS, deprecated, renamed: "TwoSidedVisionOSViewModifier")
 struct TwoSidedViewModifier<Back: View>: ViewModifier {
     let angle: Angle
     let axis: (x: CGFloat, y: CGFloat, z: CGFloat)
@@ -89,6 +70,7 @@ extension View {
     ///   - perspective: The relative vanishing point with a default of 1 for this rotation.
     ///   - back: View to show on the back.
     /// - Returns: A rotated view with another view showing on the back.
+    @available(visionOS, deprecated, message: "Use rotation3DEffect without perspective")
     public func rotation3DEffect<Back: View>(
         _ angle: Angle,
         axis: (x: CGFloat, y: CGFloat, z: CGFloat),
@@ -101,6 +83,7 @@ extension View {
     }
 }
 
+@available(visionOS, deprecated, message: "Use rotation3DEffect without perspective")
 struct TwoSidedView_Previews: PreviewProvider {
     struct PreviewData: View {
         @State private var angle: Angle = .zero

--- a/Sources/FrameUp/TwoSidedView/TwoSidedVisionOSView.swift
+++ b/Sources/FrameUp/TwoSidedView/TwoSidedVisionOSView.swift
@@ -1,6 +1,6 @@
 //
 //  TwoSidedVisionOSView.swift
-//  
+//
 //
 //  Created by Ryan Lintott on 2023-08-11.
 //
@@ -8,23 +8,25 @@
 #if os(visionOS)
 import SwiftUI
 
-struct TwoSidedVisionOSViewModifier<Back: View>: ViewModifier {
+struct TwoSidedVisionOSView<Front: View, Back: View>: View {
     let angle: Angle
     let axis: RotationAxis3D
     let anchor: UnitPoint3D
+    let front: () -> Front
     let back: () -> Back
     
-    init(_ angle: Angle, axis: RotationAxis3D, anchor: UnitPoint3D, back: @escaping () -> Back) {
+    init(angle: Angle, axis: RotationAxis3D, anchor: UnitPoint3D = .center, front: @escaping () -> Front, back: @escaping () -> Back) {
         self.angle = angle
         self.axis = axis
         self.anchor = anchor
+        self.front = front
         self.back = back
     }
     
     var backAngle: Angle { angle + .degrees(180) }
     
     var thickness: Double {
-        0.1
+        2
     }
     
     var isFaceUp: Bool {
@@ -34,54 +36,36 @@ struct TwoSidedVisionOSViewModifier<Back: View>: ViewModifier {
         }
     }
     
-    func body(content: Content) -> some View {
-        ZStack {
-            back()
-                .offset(z: thickness)
-                .rotation3DEffect(backAngle, axis: axis, anchor: anchor)
-                .accessibilityElement(children: isFaceUp ? .ignore : .contain)
-                .accessibilityHidden(!isFaceUp)
-            
-            content
-                .offset(z: thickness)
-                .rotation3DEffect(angle, axis: axis, anchor: anchor)
-                .accessibilityElement(children: isFaceUp ? .contain : .ignore)
-                .accessibilityHidden(isFaceUp)
-        }
-    }
-}
-
-extension View {
-    /// Rotates this view’s rendered output in three dimensions around the given axis of rotation with a closure containing a different view on the back.
-    /// - Parameters:
-    ///   - angle: The angle at which to rotate the view.
-    ///   - axis: The x, y and z elements that specify the axis of rotation.
-    ///   - anchor: The location with a default of center that defines a point in 3D space about which the rotation is anchored.
-    ///   - anchorZ: The location with a default of 0 that defines a point in 3D space about which the rotation is anchored.
-    ///   - perspective: The relative vanishing point with a default of 1 for this rotation.
-    ///   - back: View to show on the back.
-    /// - Returns: A rotated view with another view showing on the back.
-    public func rotation3DEffect<Back: View>(
-        _ angle: Angle,
-        axis: RotationAxis3D,
-        anchor: UnitPoint3D = .center,
-        back: @escaping () -> Back
-    ) -> some View {
-        modifier(TwoSidedVisionOSViewModifier(angle, axis: axis, anchor: anchor, back: back))
+    var body: some View {
+        front()
+            .accessibilityElement(children: isFaceUp ? .contain : .ignore)
+            .accessibilityHidden(isFaceUp)
+            .background {
+                back()
+                    .accessibilityElement(children: isFaceUp ? .ignore : .contain)
+                    .accessibilityHidden(!isFaceUp)
+                    .offset(z: -thickness / 2)
+                    .rotation3DEffect(.degrees(180), axis: axis, anchor: .init(x: anchor.x, y: anchor.y, z: anchor.z - thickness))
+            }
+            .offset(z: -thickness / 2)
+            .rotation3DEffect(angle, axis: axis, anchor: anchor)
     }
 }
 
 struct TwoSidedVisionOSView_Previews: PreviewProvider {
     struct PreviewData: View {
-        @State private var angle: Angle = .degrees(90)
+        @State private var angle: Angle = .degrees(0)
         @State private var axis: Axis = .horizontal
         
         var body: some View {
             VStack {
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(.blue)
-                    .overlay(Text("Up"))
-                    .rotation3DEffect(angle, axis: axis == .horizontal ? .y : .x) {
+                TwoSidedVisionOSView(
+                    angle: angle,
+                    axis: axis == .horizontal ? .y : .x) {
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(.blue)
+                            .overlay(Text("Up"))
+                    } back: {
                         RoundedRectangle(cornerRadius: 20)
                             .fill(.red)
                             .overlay(Text("Down"))

--- a/Sources/FrameUp/TwoSidedView/TwoSidedVisionOSView.swift
+++ b/Sources/FrameUp/TwoSidedView/TwoSidedVisionOSView.swift
@@ -1,6 +1,6 @@
 //
 //  TwoSidedVisionOSView.swift
-//
+//  FrameUp
 //
 //  Created by Ryan Lintott on 2023-08-11.
 //
@@ -12,19 +12,15 @@ struct TwoSidedVisionOSViewModifier<Back: View>: ViewModifier {
     let angle: Angle
     let axis: RotationAxis3D
     let anchor: UnitPoint3D
+    let thickness: CGFloat
     let back: Back
     
-    init(angle: Angle, axis: RotationAxis3D, anchor: UnitPoint3D = .center, back: Back) {
+    init(angle: Angle, axis: RotationAxis3D, anchor: UnitPoint3D = .center, thickness: CGFloat? = nil, back: Back) {
         self.angle = angle
         self.axis = axis
         self.anchor = anchor
+        self.thickness = thickness ?? 2
         self.back = back
-    }
-    
-    var backAngle: Angle { angle + .degrees(180) }
-    
-    var thickness: Double {
-        2
     }
     
     var isFaceUp: Bool {
@@ -42,10 +38,10 @@ struct TwoSidedVisionOSViewModifier<Back: View>: ViewModifier {
                 back
                     .accessibilityElement(children: isFaceUp ? .ignore : .contain)
                     .accessibilityHidden(!isFaceUp)
-                    .offset(z: -thickness / 2)
-                    .rotation3DEffect(.degrees(180), axis: axis, anchor: .init(x: anchor.x, y: anchor.y, z: anchor.z - thickness))
+                    .offset(z: -thickness)
+                    .rotation3DEffect(.degrees(180), axis: axis, anchor: .center)
             }
-            .offset(z: -thickness / 2)
+            .offset(z: thickness / 2)
             .rotation3DEffect(angle, axis: axis, anchor: anchor)
     }
 }
@@ -64,9 +60,10 @@ extension View {
         _ angle: Angle,
         axis: RotationAxis3D,
         anchor: UnitPoint3D = .center,
+        thickness: CGFloat? = nil,
         back: () -> Back
     ) -> some View {
-        modifier(TwoSidedVisionOSViewModifier(angle: angle, axis: axis, anchor: anchor, back: back()))
+        modifier(TwoSidedVisionOSViewModifier(angle: angle, axis: axis, anchor: anchor, thickness: thickness, back: back()))
     }
 }
 
@@ -80,12 +77,17 @@ struct TwoSidedVisionOSView_Previews: PreviewProvider {
                 RoundedRectangle(cornerRadius: 20)
                     .fill(.blue)
                     .overlay(Text("Up"))
-                    .rotation3DEffect(angle, axis: axis == .horizontal ? .y : .x) {
+                    .rotation3DEffect(
+                        angle,
+                        axis: axis == .horizontal ? .y : .x,
+                        thickness: 2
+                    ) {
                         RoundedRectangle(cornerRadius: 20)
                             .fill(.red)
                             .overlay(Text("Down"))
                     }
                     .padding()
+                    
                 
                 Picker("Axis", selection: $axis) {
                     ForEach(Axis.allCases, id: \.self) { axis in

--- a/Sources/FrameUp/Widget/AccessoryInlineImage.swift
+++ b/Sources/FrameUp/Widget/AccessoryInlineImage.swift
@@ -1,0 +1,37 @@
+//
+//  AccessoryInlineImage.swift
+//  FrameUp
+//
+//  Created by Ryan Lintott on 2023-09-05.
+//
+
+import SwiftUI
+
+#if os(iOS)
+@available(iOSApplicationExtension 16.0, *)
+public struct AccessoryInlineImage: View {
+    public let uiImage: UIImage
+    
+    public init?(_ name: String, bundle: Bundle? = nil, renderingMode: UIImage.RenderingMode = .alwaysTemplate) {
+        let widgetSize = WidgetSize.accessoryInline
+        let imageSize = widgetSize.sizeForCurrentDevice(iPadTarget: .designCanvas) ?? widgetSize.minimumSize
+        
+        guard let uiImage = UIImage(named: name, in: bundle, with: nil)?
+                .scaledToFit(imageSize)?
+                .withRenderingMode(renderingMode)
+        else { return nil}
+        self.uiImage = uiImage
+    }
+    
+    public init?(symbolName: String, bundle: Bundle? = nil, renderingMode: UIImage.RenderingMode = .alwaysTemplate) {
+        guard let uiImage = UIImage(named: symbolName, in: bundle, with: nil)?
+            .withRenderingMode(renderingMode)
+        else { return nil}
+        self.uiImage = uiImage
+    }
+    
+    public var body: Image {
+        Image(uiImage: uiImage)
+    }
+}
+#endif

--- a/Sources/FrameUp/Widget/AccessoryInlineImage.swift
+++ b/Sources/FrameUp/Widget/AccessoryInlineImage.swift
@@ -12,26 +12,30 @@ import SwiftUI
 public struct AccessoryInlineImage: View {
     public let uiImage: UIImage
     
-    public init?(_ name: String, bundle: Bundle? = nil, renderingMode: UIImage.RenderingMode = .alwaysTemplate) {
-        let widgetSize = WidgetSize.accessoryInline
-        let imageSize = widgetSize.sizeForCurrentDevice(iPadTarget: .designCanvas) ?? widgetSize.minimumSize
-        
-        guard let uiImage = UIImage(named: name, in: bundle, with: nil)?
+    public init?(_ uiImage: UIImage) {
+        if uiImage.isSymbolImage {
+            self.uiImage = uiImage.withRenderingMode(.alwaysTemplate)
+        } else {
+            let widgetSize = WidgetSize.accessoryInline
+            let imageSize = widgetSize.sizeForCurrentDevice(iPadTarget: .designCanvas) ?? widgetSize.minimumSize
+            
+            guard let uiImage = uiImage
                 .scaledToFit(imageSize)?
-                .withRenderingMode(renderingMode)
-        else { return nil}
-        self.uiImage = uiImage
-    }
-    
-    public init?(symbolName: String, bundle: Bundle? = nil, renderingMode: UIImage.RenderingMode = .alwaysTemplate) {
-        guard let uiImage = UIImage(named: symbolName, in: bundle, with: nil)?
-            .withRenderingMode(renderingMode)
-        else { return nil}
-        self.uiImage = uiImage
+                .withRenderingMode(.alwaysTemplate)
+            else { return nil}
+            self.uiImage = uiImage
+        }
     }
     
     public var body: Image {
         Image(uiImage: uiImage)
+    }
+}
+
+public extension AccessoryInlineImage {
+    init?(_ name: String, bundle: Bundle? = nil) {
+        guard let uiImage = UIImage(named: name, in: bundle, with: nil) else { return nil}
+        self.init(uiImage)
     }
 }
 #endif

--- a/Sources/FrameUp/Widget/WidgetDemoFrame.swift
+++ b/Sources/FrameUp/Widget/WidgetDemoFrame.swift
@@ -87,14 +87,19 @@ public extension WidgetDemoFrame {
 public extension WidgetDemoFrame {
     /// Creates a widget demo view for a specified widget size and corner radius for the current device.
     /// - Parameters:
-    ///   - widgetSize: Size of widget (all sizes are supported regardless of iOS version or device type)
+    ///   - widgetSize: Size of widget (all sizes are supported regardless of iOS version)
     ///   - cornerRadius: Size of the corner radius relative to homeScreenSize
     ///   - content: view with parameters for the designCanvasSize and designCornerRadius
-    init(_ widgetSize: WidgetSize, cornerRadius: CGFloat? = nil, content: @escaping SizeAndCornerRadius) {
+    init?(_ widgetSize: WidgetSize, cornerRadius: CGFloat? = nil, content: @escaping SizeAndCornerRadius) {
+        guard
+            let designCanvasSize = widgetSize.sizeForCurrentDevice(iPadTarget: .designCanvas),
+            let homeScreenSize = widgetSize.sizeForCurrentDevice(iPadTarget: .homeScreen)
+        else { return nil }
+        
         self.init(
             widgetSize: widgetSize,
-            designCanvasSize: widgetSize.sizeForCurrentDevice(iPadTarget: .designCanvas),
-            homeScreenSize: widgetSize.sizeForCurrentDevice(iPadTarget: .homeScreen),
+            designCanvasSize: designCanvasSize,
+            homeScreenSize: homeScreenSize,
             cornerRadius: cornerRadius,
             content: content
         )

--- a/Sources/FrameUp/Widget/WidgetFamily+extensions.swift
+++ b/Sources/FrameUp/Widget/WidgetFamily+extensions.swift
@@ -5,6 +5,7 @@
 //  Created by Ryan Lintott on 2021-05-28.
 //
 
+#if canImport(WidgetKit)
 import SwiftUI
 import WidgetKit
 
@@ -30,3 +31,4 @@ public extension WidgetFamily {
         }
     }
 }
+#endif

--- a/Sources/FrameUp/Widget/WidgetRelativeShape.swift
+++ b/Sources/FrameUp/Widget/WidgetRelativeShape.swift
@@ -5,10 +5,10 @@
 //  Created by Ryan Lintott on 2021-11-24.
 //
 
-import WidgetKit
-import SwiftUI
-
 #if os(iOS)
+import SwiftUI
+import WidgetKit
+
 @available(iOS, unavailable)
 @available(iOSApplicationExtension 14.0, *)
 /// A scalable version of ContainerRelativeShape.

--- a/Sources/FrameUp/Widget/WidgetSize+CurrentDevice.swift
+++ b/Sources/FrameUp/Widget/WidgetSize+CurrentDevice.swift
@@ -46,26 +46,29 @@ public extension WidgetSize {
     /// Size for this widget on the current device.
     /// - Parameter iPadTarget: Widget frame target. iPad widgets have a design canvas frame used for laying out the content, and a smaller Home Screen frame that the content is scaled to fit.
     /// - Returns: Size for this widget for the current device. Zero if device does not have widgets or if no size is available.
-    func sizeForCurrentDevice(iPadTarget: WidgetTarget = .homeScreen) -> CGSize {
+    func sizeForCurrentDevice(iPadTarget: WidgetTarget) -> CGSize? {
         switch Self.currentDevice {
         case .pad:
             return sizeForiPad(screenSize: Self.currentScreenSize, target: iPadTarget)
         case .phone:
             return sizeForiPhone(screenSize: Self.currentScreenSize)
         default:
-            return .zero
+            return nil
         }
     }
     
     /// How much the widget is scaled down to fit on the Home Screen.
     ///
     /// Home Screen width divided by design canvas width. iPhone value will always be 1.
-    var scaleFactorForCurrentDevice: CGFloat {
-        guard Self.currentDevice == .pad else {
+    var scaleFactorForCurrentDevice: CGFloat? {
+        switch Self.currentDevice {
+        case .pad:
+            return scaleFactorForiPad(screenSize: Self.currentScreenSize)
+        case .phone:
             return 1
+        default:
+            return nil
         }
-
-        return scaleFactorForiPad(screenSize: Self.currentScreenSize)
     }
 }
 #endif

--- a/Sources/FrameUp/Widget/WidgetSize+CurrentDevice.swift
+++ b/Sources/FrameUp/Widget/WidgetSize+CurrentDevice.swift
@@ -5,9 +5,10 @@
 //  Created by Ryan Lintott on 2022-01-25.
 //
 
-import SwiftUI
 
 #if os(iOS)
+import SwiftUI
+
 public extension WidgetSize {
     /// The screen size ignoring orientation.
     private static let currentScreenSize = UIScreen.main.fixedCoordinateSpace.bounds.size

--- a/Sources/FrameUp/Widget/WidgetSize+WidgetKit.swift
+++ b/Sources/FrameUp/Widget/WidgetSize+WidgetKit.swift
@@ -5,6 +5,7 @@
 //  Created by Ryan Lintott on 2021-09-17.
 //
 
+#if canImport(WidgetKit)
 import Foundation
 import WidgetKit
 
@@ -58,3 +59,4 @@ public extension WidgetSize {
         }
     }
 }
+#endif

--- a/Sources/FrameUp/Widget/WidgetSize.swift
+++ b/Sources/FrameUp/Widget/WidgetSize.swift
@@ -149,24 +149,24 @@ public extension WidgetSize {
     
     /// Size for this widget on an iPhone with the specified screen size.
     /// - Parameter screenSize: iPhone screen size ignoring orientation.
-    /// - Returns: Size for this widget. Zero if widget size is not available.
-    func sizeForiPhone(screenSize: CGSize) -> CGSize {
-        Self.sizesForiPhone(screenSize: screenSize)[self] ?? .zero
+    /// - Returns: Size for this widget. Nil if widget size is not available.
+    func sizeForiPhone(screenSize: CGSize) -> CGSize? {
+        Self.sizesForiPhone(screenSize: screenSize)[self]
     }
     
     /// Size for this widget on an iPad with the specified screen size.
     /// - Parameter screenSize: iPad screen size ignoring orientation.
     /// - Parameter target: Widget frame target. iPad widgets have a design canvas frame used for laying out the content, and a smaller Home Screen frame that the content is scaled to fit.
-    /// - Returns: Size for this widget. Zero if widget size is not available.
-    func sizeForiPad(screenSize: CGSize, target: WidgetTarget) -> CGSize {
-        Self.sizesForiPad(screenSize: screenSize, target: target)[self] ?? .zero
+    /// - Returns: Size for this widget. Nil if widget size is not available.
+    func sizeForiPad(screenSize: CGSize, target: WidgetTarget) -> CGSize? {
+        Self.sizesForiPad(screenSize: screenSize, target: target)[self]
     }
     
     /// Size for this widget on an iPhone with the specified screen size.
     /// - Parameter screenSize: Apple Watch size in mm.
-    /// - Returns: Size for this widget. Zero if widget size is not available.
-    func sizeForWatch(watchSize: CGFloat) -> CGSize {
-        Self.sizesForWatch(watchSize: watchSize)[self] ?? .zero
+    /// - Returns: Size for this widget. Nil if widget size is not available.
+    func sizeForWatch(watchSize: CGFloat) -> CGSize? {
+        Self.sizesForWatch(watchSize: watchSize)[self]
     }
     
     /// How much the widget is scaled down to fit on the Home Screen.
@@ -174,8 +174,11 @@ public extension WidgetSize {
     /// Home Screen width divided by design canvas width
     /// - Parameter screenSize: iPad screen size ignoring orientation.
     /// - Returns: Widget scale factor between design canvas and Home Screen.
-    func scaleFactorForiPad(screenSize: CGSize) -> CGFloat {
-        sizeForiPad(screenSize: screenSize, target: .homeScreen).width / sizeForiPad(screenSize: screenSize, target: .designCanvas).width
+    func scaleFactorForiPad(screenSize: CGSize) -> CGFloat? {
+        guard let homeScreen = sizeForiPad(screenSize: screenSize, target: .homeScreen),
+              let designCanvas = sizeForiPad(screenSize: screenSize, target: .designCanvas)
+        else { return nil }
+        return homeScreen.width / designCanvas.width
     }
 }
 

--- a/Sources/FrameUp/_Extensions-Internal/CGSize+extensions.swift
+++ b/Sources/FrameUp/_Extensions-Internal/CGSize+extensions.swift
@@ -43,4 +43,22 @@ internal extension CGSize {
     var maxDimension: CGFloat {
         proportionableSize.maxDimension
     }
+    
+    func scaledToFit(_ frame: CGSize) -> CGSize {
+        if self == .zero { return .zero }
+        switch aspectRatio - frame.aspectRatio {
+        case 0: return frame
+        case ..<0: return .init(width: frame.height * aspectRatio, height: frame.height)
+        default: return .init(width: frame.width, height: frame.height / aspectRatio)
+        }
+    }
+    
+    func scaledToFill(_ frame: CGSize) -> CGSize {
+        if self == .zero { return .zero }
+        switch aspectRatio - frame.aspectRatio {
+        case 0: return frame
+        case ..<0: return .init(width: frame.width, height: frame.height / aspectRatio)
+        default: return .init(width: frame.height * aspectRatio, height: frame.height)
+        }
+    }
 }

--- a/Sources/FrameUp/_Extensions-Internal/Dictionary+extensions.swift
+++ b/Sources/FrameUp/_Extensions-Internal/Dictionary+extensions.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Dictionary+extensions.swift
+//  FrameUp
 //
 //  Created by Ryan Lintott on 2022-09-09.
 //

--- a/Sources/FrameUp/_Extensions-Internal/View+IfAvailable.swift
+++ b/Sources/FrameUp/_Extensions-Internal/View+IfAvailable.swift
@@ -1,0 +1,20 @@
+//
+//  View+IfAvailable.swift
+//  DragAndDrop
+//
+//  Created by Ryan Lintott on 2023-07-14.
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies the given transform.
+    ///
+    /// Useful for availability branching on view modifiers. Do not branch with any properties that may change during runtime as this will cause errors.
+    /// - Parameters:
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: The view transformed by the transform.
+    func ifAvailable<Content: View>(@ViewBuilder _ transform: (Self) -> Content) -> some View {
+        transform(self)
+    }
+}

--- a/Sources/FrameUp/_Extensions-Public/UIImage+publicExtensions.swift
+++ b/Sources/FrameUp/_Extensions-Public/UIImage+publicExtensions.swift
@@ -11,6 +11,7 @@ import SwiftUI
 public extension UIImage {
     func scale(_ scale: CGFloat) -> UIImage? {
         let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        /// Change this to UIGraphicsImageRenderer(size: newSize)
         UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
         draw(in: .init(origin: .zero, size: newSize), blendMode: .normal, alpha: 1)
         let newImage = UIGraphicsGetImageFromCurrentImageContext()

--- a/Sources/FrameUp/_Extensions-Public/UIImage+publicExtensions.swift
+++ b/Sources/FrameUp/_Extensions-Public/UIImage+publicExtensions.swift
@@ -1,0 +1,30 @@
+//
+//  UIImage+publicExtensions.swift
+//  FrameUp
+//
+//  Created by Ryan Lintott on 2023-09-02.
+//
+
+import SwiftUI
+
+#if os(iOS)
+public extension UIImage {
+    func scale(_ scale: CGFloat) -> UIImage? {
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
+        draw(in: .init(origin: .zero, size: newSize), blendMode: .normal, alpha: 1)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage
+    }
+    
+    func scaledToFit(_ frame: CGSize) -> UIImage? {
+        let newSize = size.scaledToFit(frame)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
+        draw(in: .init(origin: .zero, size: newSize), blendMode: .normal, alpha: 1)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage
+    }
+}
+#endif


### PR DESCRIPTION
- Added AccessoryInlineImage to adjust any image or symbol so that it can render in the accessory inline widget. 
- Added UIImage extensions scale() and scaledToFit() to adjust images for accessory inline widget.
- Changed WidgetSize functions sizeForCurrentDevice, sizeForiPhone, sizeForiPad, and sizeForWatch to return nil if a specific size is not known for that widget. Previously they returned zero.

iOS 17
- Fixed SmartScrollView so that scrollBounceBehavior works as expected in iOS 17

visionOS
- Added support for visionOS
- Deprecated FlippingView, TwoSidedView and rotation3DEffect (with back view) with perspective
- Added TwoSidedVisionOSViewModifier and rotation3DEffect (with back view) to match new visionOS rotation modifier. This modifier is still buggy most likely due to visionOS betas changing